### PR TITLE
Schizophreni branch

### DIFF
--- a/chap4_ simple neural network/tutorial_minst_fnn-numpy-exercise.ipynb
+++ b/chap4_ simple neural network/tutorial_minst_fnn-numpy-exercise.ipynb
@@ -71,7 +71,7 @@
     "&=\\frac{\\partial l}{\\partial y}y\\frac{\\partial log(y)}{\\partial x}\n",
     "\\end{align}\n",
     "由于$log(y)=x - log(\\sum_{k}e^{x_{ik}})$, 求导方便\n",
-    "最后结果为\n",
+    "最后反传公式为\n",
     "\\begin{equation}\n",
     "\\nabla_x l = \\nabla_y l \\odot y - y\\odot \\sum_{k}(y\\odot\\nabla_y l)_{:, k}\n",
     "\\end{equation}\n",

--- a/chap4_ simple neural network/tutorial_minst_fnn-numpy-exercise.ipynb
+++ b/chap4_ simple neural network/tutorial_minst_fnn-numpy-exercise.ipynb
@@ -9,9 +9,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[PhysicalDevice(name='/physical_device:GPU:0', device_type='GPU')]\n"
+     ]
+    }
+   ],
    "source": [
     "import os\n",
     "import numpy as np\n",
@@ -27,7 +35,16 @@
     "    x = x/255.0\n",
     "    x_test = x_test/255.0\n",
     "    \n",
-    "    return (x, y), (x_test, y_test)"
+    "    return (x, y), (x_test, y_test)\n",
+    "\n",
+    "\"\"\"\n",
+    "设置GPU使用按需增长\n",
+    "Changed by Schizophreni\n",
+    "\"\"\"\n",
+    "gpus = tf.config.experimental.list_physical_devices(device_type='GPU')\n",
+    "print(gpus)\n",
+    "for gpu in gpus:\n",
+    "    tf.config.experimental.set_memory_growth(gpu, True)"
    ]
   },
   {
@@ -38,8 +55,33 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* Softmax BP 简化版\n",
+    "给定输入$x$, 输出$y=softmax(x)$, 满足以下条件\n",
+    "\\begin{equation}\n",
+    "y_{ij} = \\frac{e^{x_{ij}}}{\\sum_{k}e^{x_{ik}}}\n",
+    "\\end{equation}\n",
+    "已知loss对$y$的微分为$\\nabla_y l$，反向传播求loss对x的微分$\\nabla_x l$\n",
+    "根据链式法则如下\n",
+    "\\begin{align}\n",
+    "\\nabla_x l &= \\frac{\\partial l}{\\partial y}\\frac{\\partial y}{\\partial x}\n",
+    "&=\\frac{\\partial l}{\\partial y}\\frac{\\partial y}{\\partial log(y)}\\frac{\\partial log(y)}{\\partial x}\n",
+    "&=\\frac{\\partial l}{\\partial y}y\\frac{\\partial log(y)}{\\partial x}\n",
+    "\\end{align}\n",
+    "由于$log(y)=x - log(\\sum_{k}e^{x_{ik}})$, 求导方便\n",
+    "最后结果为\n",
+    "\\begin{equation}\n",
+    "\\nabla_x l = \\nabla_y l \\odot y - y\\odot \\sum_{k}(y\\odot\\nabla_y l)_{:, k}\n",
+    "\\end{equation}\n",
+    "其中$\\odot$表示elementwise multiplication\n",
+    "* Derived by Schizophreni"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,25 +142,24 @@
     "        '''\n",
     "        x: shape(N, c)\n",
     "        '''\n",
+    "        x = x - np.max(x, axis=-1, keepdims=True)  ## 避免上溢和下溢, Changed by Schizophreni\n",
     "        x_exp = np.exp(x)\n",
     "        partition = np.sum(x_exp, axis=1, keepdims=True)\n",
     "        out = x_exp/(partition+self.epsilon)\n",
     "        \n",
     "        self.mem['out'] = out\n",
-    "        self.mem['x_exp'] = x_exp\n",
+    "        ## self.mem['x_exp'] = x_exp\n",
     "        return out\n",
     "    \n",
     "    def backward(self, grad_y):\n",
     "        '''\n",
     "        grad_y: same shape as x\n",
+    "        Changed by Schizophreni\n",
     "        '''\n",
     "        s = self.mem['out']\n",
-    "        sisj = np.matmul(np.expand_dims(s,axis=2), np.expand_dims(s, axis=1)) # (N, c, c)\n",
-    "        g_y_exp = np.expand_dims(grad_y, axis=1)\n",
-    "        tmp = np.matmul(g_y_exp, sisj) #(N, 1, c)\n",
-    "        tmp = np.squeeze(tmp, axis=1)\n",
-    "        tmp = -tmp+grad_y*s \n",
-    "        return tmp\n",
+    "        tmp = np.multiply(s, grad_y)\n",
+    "        grad_x = tmp - np.multiply(s, np.sum(tmp, axis=-1, keepdims=True))\n",
+    "        return grad_x\n",
     "    \n",
     "class Log:\n",
     "    '''\n",
@@ -156,7 +197,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -242,40 +283,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[  0.          29.88862875   0.           0.           0.\n",
-      "    0.        ]\n",
-      " [363.02160168   0.           0.           0.           0.\n",
-      "    0.        ]\n",
-      " [  0.           0.           0.          12.25561872   0.\n",
-      "    0.        ]\n",
-      " [  0.           0.           0.           0.           0.\n",
-      "   53.54971193]\n",
-      " [689.96870449   0.           0.           0.           0.\n",
-      "    0.        ]]\n",
-      "----------------------------------------\n",
-      "[[  0.          29.88862875   0.           0.           0.\n",
-      "    0.        ]\n",
-      " [363.02160181   0.           0.           0.           0.\n",
-      "    0.        ]\n",
-      " [  0.           0.           0.          12.25561872   0.\n",
-      "    0.        ]\n",
-      " [  0.           0.           0.           0.           0.\n",
-      "   53.54971193]\n",
-      " [689.96870497   0.           0.           0.           0.\n",
-      "    0.        ]]\n"
-     ]
+     "data": {
+      "text/plain": [
+       "\"import tensorflow as tf\\nx = np.random.normal(size=[5, 6]) ## 将定义x提前，否则label定义报错，Changed by Schizophreni\\nlabel = np.zeros_like(x)\\nlabel[0, 1]=1.\\nlabel[1, 0]=1\\nlabel[2, 3]=1\\nlabel[3, 5]=1\\nlabel[4, 0]=1\\n\\n\\nW1 = np.random.normal(size=[6, 5])\\nW2 = np.random.normal(size=[5, 6])\\n\\nmul_h1 = Matmul()\\nmul_h2 = Matmul()\\nrelu = Relu()\\nsoftmax = Softmax()\\nlog = Log()\\n\\nh1 = mul_h1.forward(x, W1) # shape(5, 4)\\nh1_relu = relu.forward(h1)\\nh2 = mul_h2.forward(h1_relu, W2)\\nh2_soft = softmax.forward(h2)\\nh2_log = log.forward(h2_soft)\\n\\n\\nh2_log_grad = log.backward(label)\\nh2_soft_grad = softmax.backward(h2_log_grad)\\nh2_grad, W2_grad = mul_h2.backward(h2_soft_grad)\\nh1_relu_grad = relu.backward(h2_grad)\\nh1_grad, W1_grad = mul_h1.backward(h1_relu_grad)\\n\\n# print(h2_log_grad)\\nprint(h2_soft_grad) ## 检查softmax反传结果，Changed by Schizophreni\\nprint('--'*20)\\n# print(W2_grad)\\n\\nwith tf.GradientTape() as tape:\\n    x, W1, W2, label = tf.constant(x), tf.constant(W1), tf.constant(W2), tf.constant(label)\\n    tape.watch(W1)\\n    tape.watch(W2)\\n    h1 = tf.matmul(x, W1)\\n    h1_relu = tf.nn.relu(h1)\\n    h2 = tf.matmul(h1_relu, W2)\\n    prob = tf.nn.softmax(h2)\\n    log_prob = tf.math.log(prob)\\n    loss = tf.reduce_sum(label * log_prob)\\n    grads = tape.gradient(loss, [h2])  ## prob - > h2, 检查softmax反传结果， Changed by Schizophreni\\n    print (grads[0].numpy())\\n    \""
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
     "import tensorflow as tf\n",
-    "\n",
+    "x = np.random.normal(size=[5, 6]) ## 将定义x提前，否则label定义报错，Changed by Schizophreni\n",
     "label = np.zeros_like(x)\n",
     "label[0, 1]=1.\n",
     "label[1, 0]=1\n",
@@ -283,7 +309,7 @@
     "label[3, 5]=1\n",
     "label[4, 0]=1\n",
     "\n",
-    "x = np.random.normal(size=[5, 6])\n",
+    "\n",
     "W1 = np.random.normal(size=[6, 5])\n",
     "W2 = np.random.normal(size=[5, 6])\n",
     "\n",
@@ -306,7 +332,8 @@
     "h1_relu_grad = relu.backward(h2_grad)\n",
     "h1_grad, W1_grad = mul_h1.backward(h1_relu_grad)\n",
     "\n",
-    "print(h2_log_grad)\n",
+    "# print(h2_log_grad)\n",
+    "print(h2_soft_grad) ## 检查softmax反传结果，Changed by Schizophreni\n",
     "print('--'*20)\n",
     "# print(W2_grad)\n",
     "\n",
@@ -320,7 +347,7 @@
     "    prob = tf.nn.softmax(h2)\n",
     "    log_prob = tf.math.log(prob)\n",
     "    loss = tf.reduce_sum(label * log_prob)\n",
-    "    grads = tape.gradient(loss, [prob])\n",
+    "    grads = tape.gradient(loss, [h2])  ## prob - > h2, 检查softmax反传结果， Changed by Schizophreni\n",
     "    print (grads[0].numpy())"
    ]
   },
@@ -497,9 +524,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "TensorFlow2",
    "language": "python",
-   "name": "python3"
+   "name": "tf2"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
Add code for setting the demand of GPU with tensorflow 2.0
Simplify the codes for softmax of numpy implementation in Chap4 tutorial_minst_fnn-numpy-exercise.ipynb, including forward and backward
Add a brief and simpler derivation of back propogation for softmax. 
All codes changed have been annotated with "Changed by Schizophreni", the author can utilize this to find the changes and modify the code.